### PR TITLE
Check if the object is Enumerable instead of `each`

### DIFF
--- a/lib/resubject/builder.rb
+++ b/lib/resubject/builder.rb
@@ -33,7 +33,7 @@ module Resubject
     # @see .present_all
     #
     def self.present(objects, template, *presenters)
-      if objects.respond_to?(:each)
+      if objects.is_a? Enumerable
         Builder.present_all(objects, template, *presenters)
       else
         Builder.present_one(objects, template, *presenters)


### PR DESCRIPTION
Biggest example here is a `Struct` which does include `each` method,
but the semantics are completely different.

Just because a class has a method called `each` it doesn't mean that the
class is some kind of list/array container. Every object which wants to
behave like a list should include `Enumerable` since it provides a lot
of functionality, like `map`.

This is also a fix for #5.
